### PR TITLE
Add additional options parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,12 @@ const addBeforeRule = (rulesSource, ruleMatcher, value) => {
   rules.splice(index, 0, value);
 };
 
-module.exports = function(config, env) {
+module.exports = function (config, env, opts = {}) {
   const svgReactLoader = {
     test: /\.svg$/,
     // loader: require.resolve('svg-react-loader')
-    loader: require.resolve("svg-sprite-loader")
+    loader: require.resolve("svg-sprite-loader"),
+    ...opts,
   };
 
   addBeforeRule(config.module.rules, fileLoaderMatcher, svgReactLoader);


### PR DESCRIPTION
Hi, can you add some parameter to function for pass a additional options ?
For example i want to specify this:
`{ include: path.resolve('./my_path_to_file') }` or something else that webpack loaders config supports.